### PR TITLE
Adiciona offsets no mapa

### DIFF
--- a/mapa_exemplo.R
+++ b/mapa_exemplo.R
@@ -11,8 +11,15 @@ geojson_file <- geojson_list(mapa, geometry = "MultiPolygon")
 dados <- mapa %>% 
   as_tibble() %>% 
   mutate(valor = sample(1:nrow(.)), 
-         tooltip = paste0(name_region, "<br>Valor: ", valor))
-
+         tooltip = paste0(name_region, "<br>Valor: ", valor)) |> 
+  mutate(
+    # cria offsets x e y, definidos por trial and error
+    offset_x = c(0, 0, -50, 20, 0),
+    offset_y = c(0, 0, 0, -20, 0),
+    # cria uma lista com os parâmetros customizados
+    dataLabels = purrr::map2(offset_x, offset_y, \(x, y) list(x = x, y = y))
+  ) |> 
+  select(-offset_x, -offset_y)
 
 highchart(type = "map") %>%
   hc_add_series_map(map = geojson_file,
@@ -23,7 +30,7 @@ highchart(type = "map") %>%
                                       # align = "center"
                                       # verticalAlign = "middle" 
                                       # allowOverlap = FALSE
-                                      ),
+                    ),
                     value = "valor",
                     joinBy = c("name_region", "name_region")) %>% 
   hc_tooltip(


### PR DESCRIPTION
Adicionei isso no objeto `dados`:

```r
  mutate(
    offset_x = c(0, 0, -50, 20, 0),
    offset_y = c(0, 0, 0, -20, 0),
    dataLabels = purrr::map2(offset_x, offset_y, \(x, y) list(x = x, y = y))
  ) |> 
  select(-offset_x, -offset_y)
```

Ficou assim:

![image](https://github.com/user-attachments/assets/5e6aa651-9121-4a33-b937-512d29a1cff6)
